### PR TITLE
Defer deleting until after confirmation

### DIFF
--- a/git-coco
+++ b/git-coco
@@ -40,14 +40,14 @@ remove() {
         fail "Usage: git coco rm <repo>"
     fi
 
-    output=$(aws codecommit delete-repository \
-        --repository-name $repo)
-
     read -p "Are you sure? [Y/n] " confirmation
 
     if [ "$confirmation" != "Y" ]; then
         exit
     fi
+
+    output=$(aws codecommit delete-repository \
+        --repository-name $repo)
 
     if [ -z "$output" ]; then
         fail "No such repo: $repo"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current implementation of "git-coco" invokes "`aws codecommit delete-repository`" prior to asking for confirmation, defeating the point of prompting for confirmation.  This changeset re-orders that so the confirmation prompt is useful.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
