### PR TITLE
Parallelized prlist function

### DIFF
--- a/git-coco
+++ b/git-coco
@@ -279,21 +279,24 @@ prlist() {
 
     # Get and parse information for each PR
     for pull_request in $list_of_prs; do
-        local pull_info="$(aws_cli codecommit get-pull-request \
-        --pull-request-id "$pull_request" \
-        --query "$pr_query" \
-        --output text)"
+        (
+            local pull_info="$(aws_cli codecommit get-pull-request \
+            --pull-request-id "$pull_request" \
+            --query "$pr_query" \
+            --output text)"
 
-        local dst_branch src_branch pull_id author title
+            local dst_branch src_branch pull_id author title
 
-        IFS=$'\t' read -r author dst_branch pull_id src_branch title <<< "${pull_info}"
+            IFS=$'\t' read -r author dst_branch pull_id src_branch title <<< "${pull_info}"
 
-        author="$(echo $author | awk -F '/' '{print $NF}')"
-        dst_branch="$(echo "${dst_branch/refs\/heads\/}")"
-        src_branch="$(echo "${src_branch/refs\/heads\/}")"
+            author="$(echo $author | awk -F '/' '{print $NF}')"
+            dst_branch="$(echo "${dst_branch/refs\/heads\/}")"
+            src_branch="$(echo "${src_branch/refs\/heads\/}")"
 
-        printf "$format" "$pull_id" "$title" "$dst_branch" "$src_branch" "$author"
+            printf "$format" "$pull_id" "$title" "$dst_branch" "$src_branch" "$author"
+        ) &
     done
+    wait
 }
 
 case "$command" in


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Parallelized for loop in prlist() responsible for making awscli calls and formatting pr lines decreasing runtime of prlist operation.

Runtime measurement below were measure as follows:
```
START=`date +%s`
# Switch case statement
END=`date +%s`
runtime=$(echo "$END - $START" | bc -l)
echo "Runtime: $runtime seconds"
```

Runtime test output for sequential prlist():
```
PR #       Title                                                        Branch                                                                                                                              
12         PR Branch 5                                                  bug/broken-print <- test_branch5 (qumei-Isengard)                                                                                   
11         PR 4                                                         test_branch3 <- test_branch4 (qumei-Isengard)                                                                                       
10         PR 3                                                         feature/cpp-hello <- test_branch3 (qumei-Isengard)                                                                                  
9          Test PR 1                                                    main <- test-branch1 (qumei-Isengard)                                                                                               
8          Feature test 2                                               main <- test_branch2 (qumei-Isengard)                                                                                               
6          Feature Request - Cpp Hello                                  main <- feature/cpp-hello (qumei-Isengard)
5          Bug Fix - Broken Print                                       main <- bug/broken-print (qumei-Isengard)
4          Feature Request - Python Hello                               main <- feature/python-hello (qumei-Isengard)
Runtime: 13 seconds
```

Runtime test output for parallel prlist():
```
PR #       Title                                                        Branch                                                                                               
12         PR Branch 5                                                  bug/broken-print <- test_branch5 (qumei-Isengard)
9          Test PR 1                                                    main <- test-branch1 (qumei-Isengard)
11         PR 4                                                         test_branch3 <- test_branch4 (qumei-Isengard)
8          Feature test 2                                               main <- test_branch2 (qumei-Isengard)
4          Feature Request - Python Hello                               main <- feature/python-hello (qumei-Isengard)
6          Feature Request - Cpp Hello                                  main <- feature/cpp-hello (qumei-Isengard)
5          Bug Fix - Broken Print                                       main <- bug/broken-print (qumei-Isengard)
10         PR 3                                                         feature/cpp-hello <- test_branch3 (qumei-Isengard)
Runtime: 5 seconds
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
